### PR TITLE
add uiControlSetFocus to restore control focus after message box

### DIFF
--- a/common/control.c
+++ b/common/control.c
@@ -57,6 +57,11 @@ void uiControlDisable(uiControl *c)
 	(*(c->Disable))(c);
 }
 
+void uiControlSetFocus(uiControl *c)
+{
+	(*(c->SetFocus))(c);
+}
+
 #define uiprivControlSignature 0x7569436F
 
 uiControl *uiAllocControl(size_t size, uint32_t OSsig, uint32_t typesig, const char *typenamestr)

--- a/darwin/box.m
+++ b/darwin/box.m
@@ -380,6 +380,7 @@ uiDarwinControlDefaultHide(uiBox, view)
 uiDarwinControlDefaultEnabled(uiBox, view)
 uiDarwinControlDefaultEnable(uiBox, view)
 uiDarwinControlDefaultDisable(uiBox, view)
+uiDarwinControlDefaultSetFocus(uiBox, view)
 
 static void uiBoxSyncEnableState(uiDarwinControl *c, int enabled)
 {

--- a/darwin/form.m
+++ b/darwin/form.m
@@ -482,6 +482,7 @@ uiDarwinControlDefaultHide(uiForm, view)
 uiDarwinControlDefaultEnabled(uiForm, view)
 uiDarwinControlDefaultEnable(uiForm, view)
 uiDarwinControlDefaultDisable(uiForm, view)
+uiDarwinControlDefaultSetFocus(uiForm, view)
 
 static void uiFormSyncEnableState(uiDarwinControl *c, int enabled)
 {

--- a/darwin/grid.m
+++ b/darwin/grid.m
@@ -694,6 +694,7 @@ uiDarwinControlDefaultHide(uiGrid, view)
 uiDarwinControlDefaultEnabled(uiGrid, view)
 uiDarwinControlDefaultEnable(uiGrid, view)
 uiDarwinControlDefaultDisable(uiGrid, view)
+uiDarwinControlDefaultSetFocus(uiGrid, view)
 
 static void uiGridSyncEnableState(uiDarwinControl *c, int enabled)
 {

--- a/darwin/group.m
+++ b/darwin/group.m
@@ -43,6 +43,7 @@ uiDarwinControlDefaultHide(uiGroup, box)
 uiDarwinControlDefaultEnabled(uiGroup, box)
 uiDarwinControlDefaultEnable(uiGroup, box)
 uiDarwinControlDefaultDisable(uiGroup, box)
+uiDarwinControlDefaultSetFocus(uiGroup, box)
 
 static void uiGroupSyncEnableState(uiDarwinControl *c, int enabled)
 {

--- a/darwin/tab.m
+++ b/darwin/tab.m
@@ -115,6 +115,7 @@ uiDarwinControlDefaultHide(uiTab, tabview)
 uiDarwinControlDefaultEnabled(uiTab, tabview)
 uiDarwinControlDefaultEnable(uiTab, tabview)
 uiDarwinControlDefaultDisable(uiTab, tabview)
+uiDarwinControlDefaultSetFocus(uiTab, tabview)
 
 static void uiTabSyncEnableState(uiDarwinControl *c, int enabled)
 {

--- a/darwin/window.m
+++ b/darwin/window.m
@@ -189,6 +189,7 @@ static void uiWindowHide(uiControl *c)
 uiDarwinControlDefaultEnabled(uiWindow, window)
 uiDarwinControlDefaultEnable(uiWindow, window)
 uiDarwinControlDefaultDisable(uiWindow, window)
+uiDarwinControlDefaultSetFocus(uiWindow, window)
 
 static void uiWindowSyncEnableState(uiDarwinControl *c, int enabled)
 {

--- a/examples/controlgallery/main.c
+++ b/examples/controlgallery/main.c
@@ -17,6 +17,13 @@ static int onShouldQuit(void *data)
 	return 1;
 }
 
+static uiEntry *focusable = NULL;
+static void wideOnClicked(uiButton *b, void *data)
+{
+	if (focusable)
+		uiControlSetFocus(uiControl(focusable));
+}
+
 static uiControl *makeBasicControlsPage(void)
 {
 	uiBox *vbox;
@@ -42,6 +49,7 @@ static uiControl *makeBasicControlsPage(void)
 	uiBoxAppend(hbox,
 		uiControl(btn),
 		0);
+	uiButtonOnClicked(btn, wideOnClicked, NULL);
 
 	uiBoxAppend(vbox,
 		uiControl(uiNewLabel("This is a label. Right now, labels can only span one line.")),
@@ -59,9 +67,12 @@ static uiControl *makeBasicControlsPage(void)
 	uiFormSetPadded(entryForm, 1);
 	uiGroupSetChild(group, uiControl(entryForm));
 
+
+	focusable = uiNewEntry();
+
 	uiFormAppend(entryForm,
 		"Entry",
-		uiControl(uiNewEntry()),
+		uiControl(focusable),
 		0);
 	uiFormAppend(entryForm,
 		"Password Entry",

--- a/ui.h
+++ b/ui.h
@@ -97,6 +97,7 @@ struct uiControl {
 	int (*Enabled)(uiControl *);
 	void (*Enable)(uiControl *);
 	void (*Disable)(uiControl *);
+	void (*SetFocus)(uiControl *);
 };
 // TOOD add argument names to all arguments
 #define uiControl(this) ((uiControl *) (this))
@@ -111,6 +112,7 @@ _UI_EXTERN void uiControlHide(uiControl *);
 _UI_EXTERN int uiControlEnabled(uiControl *);
 _UI_EXTERN void uiControlEnable(uiControl *);
 _UI_EXTERN void uiControlDisable(uiControl *);
+_UI_EXTERN void uiControlSetFocus(uiControl *);
 
 _UI_EXTERN uiControl *uiAllocControl(size_t n, uint32_t OSsig, uint32_t typesig, const char *typenamestr);
 _UI_EXTERN void uiFreeControl(uiControl *);

--- a/ui_darwin.h
+++ b/ui_darwin.h
@@ -100,6 +100,11 @@ _UI_EXTERN void uiDarwinControlChildVisibilityChanged(uiDarwinControl *);
 		uiDarwinControl(c)->enabled = NO; \
 		uiDarwinControlSyncEnableState(uiDarwinControl(c), uiControlEnabledToUser(c)); \
 	}
+#define uiDarwinControlDefaultSetFocus(type, handlefield) \
+	static void type ## SetFocus(uiControl *c) \
+	{ \
+		return; \
+	}
 #define uiDarwinControlDefaultSyncEnableState(type, handlefield) \
 	static void type ## SyncEnableState(uiDarwinControl *c, int enabled) \
 	{ \
@@ -159,6 +164,7 @@ _UI_EXTERN void uiDarwinControlChildVisibilityChanged(uiDarwinControl *);
 	uiDarwinControlDefaultEnabled(type, handlefield) \
 	uiDarwinControlDefaultEnable(type, handlefield) \
 	uiDarwinControlDefaultDisable(type, handlefield) \
+	uiDarwinControlDefaultSetFocus(type, handlefield) \
 	uiDarwinControlDefaultSyncEnableState(type, handlefield) \
 	uiDarwinControlDefaultSetSuperview(type, handlefield) \
 	uiDarwinControlDefaultHugsTrailingEdge(type, handlefield) \
@@ -186,6 +192,7 @@ _UI_EXTERN void uiDarwinControlChildVisibilityChanged(uiDarwinControl *);
 	uiControl(var)->Enabled = type ## Enabled; \
 	uiControl(var)->Enable = type ## Enable; \
 	uiControl(var)->Disable = type ## Disable; \
+	uiControl(var)->SetFocus = type ## SetFocus; \
 	uiDarwinControl(var)->SyncEnableState = type ## SyncEnableState; \
 	uiDarwinControl(var)->SetSuperview = type ## SetSuperview; \
 	uiDarwinControl(var)->HugsTrailingEdge = type ## HugsTrailingEdge; \

--- a/ui_unix.h
+++ b/ui_unix.h
@@ -83,6 +83,11 @@ _UI_EXTERN void uiUnixControlSetContainer(uiUnixControl *, GtkContainer *, gbool
 	{ \
 		gtk_widget_set_sensitive(type(c)->widget, FALSE); \
 	}
+#define uiUnixControlDefaultSetFocus(type) \
+	static void type ## SetFocus(uiControl *c) \
+	{ \
+		gtk_widget_grab_focus(type(c)->widget); \
+	}
 // TODO this whole addedBefore stuff is a MASSIVE HACK.
 #define uiUnixControlDefaultSetContainer(type) \
 	static void type ## SetContainer(uiUnixControl *c, GtkContainer *container, gboolean remove) \
@@ -110,6 +115,7 @@ _UI_EXTERN void uiUnixControlSetContainer(uiUnixControl *, GtkContainer *, gbool
 	uiUnixControlDefaultEnabled(type) \
 	uiUnixControlDefaultEnable(type) \
 	uiUnixControlDefaultDisable(type) \
+	uiUnixControlDefaultSetFocus(type) \
 	uiUnixControlDefaultSetContainer(type)
 
 #define uiUnixControlAllDefaults(type) \
@@ -130,6 +136,7 @@ _UI_EXTERN void uiUnixControlSetContainer(uiUnixControl *, GtkContainer *, gbool
 	uiControl(var)->Enabled = type ## Enabled; \
 	uiControl(var)->Enable = type ## Enable; \
 	uiControl(var)->Disable = type ## Disable; \
+	uiControl(var)->SetFocus = type ## SetFocus; \
 	uiUnixControl(var)->SetContainer = type ## SetContainer;
 // TODO document
 _UI_EXTERN uiUnixControl *uiUnixAllocControl(size_t n, uint32_t typesig, const char *typenamestr);

--- a/ui_windows.h
+++ b/ui_windows.h
@@ -102,6 +102,11 @@ _UI_EXTERN void uiWindowsControlChildVisibilityChanged(uiWindowsControl *);
 		uiWindowsControl(c)->enabled = 0; \
 		uiWindowsControlSyncEnableState(uiWindowsControl(c), uiControlEnabledToUser(c)); \
 	}
+#define uiWindowsControlDefaultSetFocus(type) \
+	static void type ## SetFocus(uiControl *c) \
+	{ \
+		uiWindowsSetFocus(type(c)->hwnd); \
+	}
 #define uiWindowsControlDefaultSyncEnableState(type) \
 	static void type ## SyncEnableState(uiWindowsControl *c, int enabled) \
 	{ \
@@ -152,6 +157,7 @@ _UI_EXTERN void uiWindowsControlChildVisibilityChanged(uiWindowsControl *);
 	uiWindowsControlDefaultEnabled(type) \
 	uiWindowsControlDefaultEnable(type) \
 	uiWindowsControlDefaultDisable(type) \
+	uiWindowsControlDefaultSetFocus(type) \
 	uiWindowsControlDefaultSyncEnableState(type) \
 	uiWindowsControlDefaultSetParentHWND(type) \
 	uiWindowsControlDefaultMinimumSizeChanged(type) \
@@ -177,6 +183,7 @@ _UI_EXTERN void uiWindowsControlChildVisibilityChanged(uiWindowsControl *);
 	uiControl(var)->Enabled = type ## Enabled; \
 	uiControl(var)->Enable = type ## Enable; \
 	uiControl(var)->Disable = type ## Disable; \
+	uiControl(var)->SetFocus = type ## SetFocus; \
 	uiWindowsControl(var)->SyncEnableState = type ## SyncEnableState; \
 	uiWindowsControl(var)->SetParentHWND = type ## SetParentHWND; \
 	uiWindowsControl(var)->MinimumSize = type ## MinimumSize; \
@@ -198,6 +205,8 @@ _UI_EXTERN void uiWindowsEnsureDestroyWindow(HWND hwnd);
 // TODO document
 // TODO document that this should only be used in SetParentHWND() implementations
 _UI_EXTERN void uiWindowsEnsureSetParentHWND(HWND hwnd, HWND parent);
+
+_UI_EXTERN void uiWindowsSetFocus(HWND hwnd);
 
 // TODO document
 _UI_EXTERN void uiWindowsEnsureAssignControlIDZOrder(HWND hwnd, LONG_PTR *controlID, HWND *insertAfter);

--- a/unix/window.c
+++ b/unix/window.c
@@ -112,6 +112,7 @@ uiUnixControlDefaultHide(uiWindow)
 uiUnixControlDefaultEnabled(uiWindow)
 uiUnixControlDefaultEnable(uiWindow)
 uiUnixControlDefaultDisable(uiWindow)
+uiUnixControlDefaultSetFocus(uiWindow)
 // TODO?
 uiUnixControlDefaultSetContainer(uiWindow)
 

--- a/windows/box.cpp
+++ b/windows/box.cpp
@@ -143,6 +143,7 @@ uiWindowsControlDefaultHide(uiBox)
 uiWindowsControlDefaultEnabled(uiBox)
 uiWindowsControlDefaultEnable(uiBox)
 uiWindowsControlDefaultDisable(uiBox)
+uiWindowsControlDefaultSetFocus(uiBox)
 
 static void uiBoxSyncEnableState(uiWindowsControl *c, int enabled)
 {

--- a/windows/form.cpp
+++ b/windows/form.cpp
@@ -147,6 +147,7 @@ uiWindowsControlDefaultHide(uiForm)
 uiWindowsControlDefaultEnabled(uiForm)
 uiWindowsControlDefaultEnable(uiForm)
 uiWindowsControlDefaultDisable(uiForm)
+uiWindowsControlDefaultSetFocus(uiForm)
 
 static void uiFormSyncEnableState(uiWindowsControl *c, int enabled)
 {

--- a/windows/grid.cpp
+++ b/windows/grid.cpp
@@ -436,6 +436,7 @@ uiWindowsControlDefaultHide(uiGrid)
 uiWindowsControlDefaultEnabled(uiGrid)
 uiWindowsControlDefaultEnable(uiGrid)
 uiWindowsControlDefaultDisable(uiGrid)
+uiWindowsControlDefaultSetFocus(uiGrid)
 
 static void uiGridSyncEnableState(uiWindowsControl *c, int enabled)
 {

--- a/windows/group.cpp
+++ b/windows/group.cpp
@@ -75,6 +75,7 @@ uiWindowsControlDefaultHide(uiGroup)
 uiWindowsControlDefaultEnabled(uiGroup)
 uiWindowsControlDefaultEnable(uiGroup)
 uiWindowsControlDefaultDisable(uiGroup)
+uiWindowsControlDefaultSetFocus(uiGroup)
 
 static void uiGroupSyncEnableState(uiWindowsControl *c, int enabled)
 {

--- a/windows/tab.cpp
+++ b/windows/tab.cpp
@@ -112,6 +112,7 @@ uiWindowsControlDefaultHide(uiTab)
 uiWindowsControlDefaultEnabled(uiTab)
 uiWindowsControlDefaultEnable(uiTab)
 uiWindowsControlDefaultDisable(uiTab)
+uiWindowsControlDefaultSetFocus(uiTab)
 
 static void uiTabSyncEnableState(uiWindowsControl *c, int enabled)
 {

--- a/windows/window.cpp
+++ b/windows/window.cpp
@@ -236,6 +236,7 @@ uiWindowsControlDefaultDisable(uiWindow)
 uiWindowsControlDefaultSyncEnableState(uiWindow)
 // TODO
 uiWindowsControlDefaultSetParentHWND(uiWindow)
+uiWindowsControlDefaultSetFocus(uiWindow)
 
 static void uiWindowMinimumSize(uiWindowsControl *c, int *width, int *height)
 {

--- a/windows/winpublic.cpp
+++ b/windows/winpublic.cpp
@@ -59,3 +59,9 @@ void uiWindowsEnsureGetWindowRect(HWND hwnd, RECT *r)
 		r->bottom = 0;
 	}
 }
+
+void uiWindowsSetFocus(HWND hwnd)
+{
+	if (SetFocus(hwnd) == 0)
+		logLastError(L"error setting ficus");
+}


### PR DESCRIPTION
macos has inner focus logic and focus is not moved in case of message box.
so this function is just a stub for now to not waste time
