### PR TITLE
reset responder on msgbox

### DIFF
--- a/darwin/entry.m
+++ b/darwin/entry.m
@@ -226,6 +226,12 @@ static int defaultOnKeyEvent(uiEntry *e, uiAreaKeyEvent *ke)
 	return FALSE;
 }
 
+void uiEntryUnsetFocus(uiEntry *e)
+{
+	[e->textfield resignFirstResponder];
+	[[e->textfield window] makeFirstResponder:nil];
+}
+
 // these are based on interface builder defaults; my comments in the old code weren't very good so I don't really know what talked about what, sorry :/
 void uiprivFinishNewTextField(NSTextField *t, BOOL isEntry)
 {

--- a/ui.h
+++ b/ui.h
@@ -182,6 +182,7 @@ _UI_EXTERN void uiEntryOnChanged(uiEntry *e, void (*f)(uiEntry *e, void *data), 
 _UI_EXTERN void uiEntryOnKeyEvent(uiEntry *e, int (*f)(uiEntry *e, uiAreaKeyEvent *event));
 _UI_EXTERN int uiEntryReadOnly(uiEntry *e);
 _UI_EXTERN void uiEntrySetReadOnly(uiEntry *e, int readonly);
+_UI_EXTERN void uiEntryUnsetFocus(uiEntry *e);
 _UI_EXTERN uiEntry *uiNewEntry(void);
 _UI_EXTERN uiEntry *uiNewPasswordEntry(void);
 _UI_EXTERN uiEntry *uiNewSearchEntry(void);

--- a/ui_darwin.h
+++ b/ui_darwin.h
@@ -103,7 +103,7 @@ _UI_EXTERN void uiDarwinControlChildVisibilityChanged(uiDarwinControl *);
 #define uiDarwinControlDefaultSetFocus(type, handlefield) \
 	static void type ## SetFocus(uiControl *c) \
 	{ \
-		return; \
+		[type(c)->handlefield becomeFirstResponder]; \
 	}
 #define uiDarwinControlDefaultSyncEnableState(type, handlefield) \
 	static void type ## SyncEnableState(uiDarwinControl *c, int enabled) \

--- a/unix/entry.c
+++ b/unix/entry.c
@@ -43,6 +43,11 @@ static int defaultOnKeyEvent(uiEntry *e, uiAreaKeyEvent *uke)
 	return GDK_EVENT_PROPAGATE;
 }
 
+void uiEntryUnsetFocus(uiEntry *e)
+{
+	// stub to cover macos workaround
+}
+
 char *uiEntryText(uiEntry *e)
 {
 	return uiUnixStrdupText(gtk_entry_get_text(e->entry));

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -106,6 +106,10 @@ static int defaultOnKeyEvent(uiEntry *e, uiAreaKeyEvent *event)
 	return FALSE;
 }
 
+void uiEntryUnsetFocus(uiEntry *e)
+{
+	// stub to cover macos workaround
+}
 
 char *uiEntryText(uiEntry *e)
 {


### PR DESCRIPTION
alternative way is to use explicit unfocusing because somehow previous code is not working on new macos